### PR TITLE
Add TDoc batch download and processing scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # SIE
-3GPP TDoc
+
+This repository provides utilities to download and process 3GPP TDoc files.
+
+## Batch download
+
+Use `batch_download.py` to fetch TDocs for a specific working group and meeting.
+
+```bash
+python batch_download.py tsg_ran/WG1_RAN1 TSGR1_92e -o downloads
+```
+
+The script parses the given FTP directory and downloads all `.zip` TDocs to the
+specified directory.
+
+## Processing TDocs
+
+After downloading, `process_tdocs.py` can unzip all archives and convert any
+Office documents to PDF (requires `libreoffice`).
+
+```bash
+python process_tdocs.py -i downloads -u unzipped -p pdf
+```
+
+Converted PDFs will keep the original TDoc file name with a `.pdf` extension.
+

--- a/batch_download.py
+++ b/batch_download.py
@@ -1,0 +1,58 @@
+import argparse
+import os
+from urllib.parse import urljoin
+import requests
+from bs4 import BeautifulSoup
+from tqdm import tqdm
+
+
+def fetch_tdoc_links(base_url):
+    """Return list of full URLs to TDoc zip files under base_url."""
+    res = requests.get(base_url)
+    res.raise_for_status()
+    soup = BeautifulSoup(res.text, 'html.parser')
+    links = []
+    for a in soup.find_all('a'):
+        href = a.get('href')
+        if href and href.lower().endswith('.zip'):
+            links.append(urljoin(base_url, href))
+    return links
+
+
+def download_file(url, out_dir):
+    local_filename = os.path.join(out_dir, os.path.basename(url))
+    with requests.get(url, stream=True) as r:
+        r.raise_for_status()
+        with open(local_filename, 'wb') as f:
+            for chunk in r.iter_content(chunk_size=8192):
+                if chunk:
+                    f.write(chunk)
+    return local_filename
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Download 3GPP TDocs in batch")
+    parser.add_argument('working_group', help='3GPP working group path (e.g. tsg_ran/WG1_RAN1)')
+    parser.add_argument('meeting', help='Meeting folder name (e.g. TSGR1_92e)')
+    parser.add_argument('-o', '--output', default='downloads', help='Output directory')
+    parser.add_argument('--root', default='https://ftp.3gpp.org', help='3GPP FTP root URL')
+    args = parser.parse_args()
+
+    base_url = f"{args.root}/{args.working_group}/{args.meeting}/Docs/"
+    os.makedirs(args.output, exist_ok=True)
+
+    links = fetch_tdoc_links(base_url)
+    if not links:
+        print('No TDocs found at', base_url)
+        return
+
+    print(f"Downloading {len(links)} files to {args.output}...")
+    for url in tqdm(links):
+        try:
+            download_file(url, args.output)
+        except Exception as e:
+            print('Failed to download', url, e)
+
+
+if __name__ == '__main__':
+    main()

--- a/process_tdocs.py
+++ b/process_tdocs.py
@@ -1,0 +1,51 @@
+import argparse
+import os
+import subprocess
+import zipfile
+from pathlib import Path
+
+
+def unzip_files(input_dir, extract_dir):
+    input_path = Path(input_dir)
+    extract_path = Path(extract_dir)
+    extract_path.mkdir(parents=True, exist_ok=True)
+    for zip_file in input_path.glob('*.zip'):
+        with zipfile.ZipFile(zip_file, 'r') as z:
+            z.extractall(extract_path)
+
+
+def convert_to_pdf(src_dir, pdf_dir):
+    src_path = Path(src_dir)
+    pdf_path = Path(pdf_dir)
+    pdf_path.mkdir(parents=True, exist_ok=True)
+
+    for doc in src_path.rglob('*'):
+        if doc.suffix.lower() in {'.doc', '.docx', '.ppt', '.pptx'}:
+            out_file = pdf_path / (doc.stem + '.pdf')
+            cmd = [
+                'libreoffice', '--headless', '--convert-to', 'pdf',
+                str(doc), '--outdir', str(pdf_path)
+            ]
+            try:
+                subprocess.run(cmd, check=True)
+            except FileNotFoundError:
+                raise RuntimeError('libreoffice is required for document conversion')
+            # rename output to match TDoc name if needed
+            converted = pdf_path / (doc.stem + '.pdf')
+            if converted.exists():
+                converted.rename(out_file)
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Unzip and convert TDoc files to PDF')
+    parser.add_argument('-i', '--input', default='downloads', help='Directory of downloaded zip files')
+    parser.add_argument('-u', '--unzipped', default='unzipped', help='Directory for unzipped files')
+    parser.add_argument('-p', '--pdf', default='pdf', help='Directory for output PDFs')
+    args = parser.parse_args()
+
+    unzip_files(args.input, args.unzipped)
+    convert_to_pdf(args.unzipped, args.pdf)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add script to download 3GPP TDocs in batch
- add script to unzip archives and convert Office documents to PDF
- document how to use the scripts

## Testing
- `python -m py_compile batch_download.py process_tdocs.py`

------
https://chatgpt.com/codex/tasks/task_e_68401fcc0a7c832aab3305b90f0113d3